### PR TITLE
Improve button focus styles

### DIFF
--- a/pattern.jst
+++ b/pattern.jst
@@ -1,0 +1,14 @@
+{{# def.definitions }}
+{{# def.errors }}
+{{# def.setupKeyword }}
+{{# def.$data }}
+
+{{
+  var $regexp = $isData
+                ? '(new RegExp(' + $schemaValue + '))'
+                : it.usePattern($schema);
+}}
+
+if ({{# def.$dataNotType:'string' }} !{{=$regexp}}.test({{=$data}}) ) {
+  {{# def.error:'pattern' }}
+} {{? $breakOnError }} else { {{?}}


### PR DESCRIPTION
Add a visible focus outline to primary buttons to improve keyboard accessibility and meet contrast requirements. Update CSS for .btn-primary:focus to use a 3px solid var(--focus-color) with outline-offset: 2px and increase specificity so hover styles don't suppress the outline.