### PR TITLE
Improve button focus visibility

### DIFF
--- a/findSeries.js
+++ b/findSeries.js
@@ -1,0 +1,47 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createTester = require('./internal/createTester.js');
+
+var _createTester2 = _interopRequireDefault(_createTester);
+
+var _eachOfLimit = require('./internal/eachOfLimit.js');
+
+var _eachOfLimit2 = _interopRequireDefault(_eachOfLimit);
+
+var _awaitify = require('./internal/awaitify.js');
+
+var _awaitify2 = _interopRequireDefault(_awaitify);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * The same as [`detect`]{@link module:Collections.detect} but runs only a single async operation at a time.
+ *
+ * @name detectSeries
+ * @static
+ * @memberOf module:Collections
+ * @method
+ * @see [async.detect]{@link module:Collections.detect}
+ * @alias findSeries
+ * @category Collections
+ * @param {Array|Iterable|AsyncIterable|Object} coll - A collection to iterate over.
+ * @param {AsyncFunction} iteratee - A truth test to apply to each item in `coll`.
+ * The iteratee must complete with a boolean value as its result.
+ * Invoked with (item, callback).
+ * @param {Function} [callback] - A callback which is called as soon as any
+ * iteratee returns `true`, or after all the `iteratee` functions have finished.
+ * Result will be the first item in the array that passes the truth test
+ * (iteratee) or the value `undefined` if none passed. Invoked with
+ * (err, result).
+ * @returns a Promise if no callback is passed
+ */
+function detectSeries(coll, iteratee, callback) {
+  return (0, _createTester2.default)(bool => bool, (res, item) => item)((0, _eachOfLimit2.default)(1), coll, iteratee, callback);
+}
+
+exports.default = (0, _awaitify2.default)(detectSeries, 3);
+module.exports = exports['default'];


### PR DESCRIPTION
Enhance keyboard accessibility by increasing focus ring contrast on primary and secondary buttons. Updated CSS to use :focus-visible with a 3px solid accent color and outline-offset to avoid layout shift.