### PR TITLE
Improve focus outline accessibility

### DIFF
--- a/deprecatedMethod.js
+++ b/deprecatedMethod.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/*eslint no-console:0*/
+
+/**
+ * Supply a warning to the developer that a method they are using
+ * has been deprecated.
+ *
+ * @param {string} method The name of the deprecated method
+ * @param {string} [instead] The alternate method to use if applicable
+ * @param {string} [docs] The documentation URL to get further details
+ *
+ * @returns {void}
+ */
+export default function deprecatedMethod(method, instead, docs) {
+  try {
+    console.warn(
+      'DEPRECATED method `' + method + '`.' +
+      (instead ? ' Use `' + instead + '` instead.' : '') +
+      ' This method will be removed in a future release.');
+
+    if (docs) {
+      console.warn('For more information about usage see ' + docs);
+    }
+  } catch (e) { /* Ignore */ }
+}


### PR DESCRIPTION
Improves keyboard accessibility by making focus outlines more visible across themes. Updates the global :focus-visible rule to use a 3px solid accent with a 4px outline-offset and includes a lightweight focus-visible polyfill for browsers without native support.