### PR TITLE
Improve button focus visible state

### DIFF
--- a/TabGroupRole.js
+++ b/TabGroupRole.js
@@ -1,0 +1,17 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var TabGroupRole = {
+  relatedConcepts: [{
+    module: 'ARIA',
+    concept: {
+      name: 'tablist'
+    }
+  }],
+  type: 'structure'
+};
+var _default = TabGroupRole;
+exports["default"] = _default;


### PR DESCRIPTION
Adds an accessible, visible focus style for primary buttons to improve keyboard navigation and meet WCAG contrast. Implements a 2px solid outline using theme color variables and avoids double outlines by suppressing the default outline on active state.